### PR TITLE
[refactor] 초기 로그인 시 유저 정보 응답 수정 및 CustomOAuth2User 리펙토링

### DIFF
--- a/src/main/java/com/gotogether/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gotogether/global/apipayload/code/status/ErrorStatus.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public enum ErrorStatus implements BaseErrorCode {
 
 	_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON5000", "서버 에러. 관리자에게 문의하세요."),
-	_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON4000", "잘못된 요청"),
+	_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON4000", "잘못된 요청입니다."),
 	_INVALID_AUTH_USER_ERROR(HttpStatus.BAD_REQUEST, "COMMON4001", "사용자 인증에 실패했습니다."),
 	_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON4002", "로그인이 필요합니다."),
 
@@ -46,6 +46,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN4001", "토큰이 만료되었습니다."),
 	_TOKEN_TYPE_ERROR(HttpStatus.BAD_REQUEST, "TOKEN4002", "토큰 타입이 잘못되었습니다."),
 	_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "TOKEN4003", "로그아웃된 토큰입니다. 다시 로그인해주세요."),
+	_TOKEN_NOT_EXISTS(HttpStatus.UNAUTHORIZED, "TOKEN4004", "토큰이 존재하지 않습니다."),
 
 	_BOOKMARK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "BOOKMARK4001", "이미 북마크된 이벤트입니다."),
 	_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4002", "북마크를 찾을 수 없습니다."),

--- a/src/main/java/com/gotogether/global/oauth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/gotogether/global/oauth/dto/CustomOAuth2User.java
@@ -31,7 +31,7 @@ public class CustomOAuth2User implements OAuth2User {
 
 	@Override
 	public String getName() {
-		return userDTO.getId().toString();
+		return userDTO.getProviderId();
 	}
 
 	public Long getId() {

--- a/src/main/java/com/gotogether/global/oauth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/gotogether/global/oauth/dto/CustomOAuth2User.java
@@ -1,10 +1,11 @@
 package com.gotogether.global.oauth.dto;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import com.gotogether.domain.user.dto.request.UserDTO;
@@ -25,31 +26,19 @@ public class CustomOAuth2User implements OAuth2User {
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+	}
 
-		Collection<GrantedAuthority> collection = new ArrayList<>();
-
-		collection.add(() -> "ROLE_USER");
-
-		return collection;
+	@Override
+	public String getName() {
+		return userDTO.getId().toString();
 	}
 
 	public Long getId() {
 		return userDTO.getId();
 	}
 
-	public String getName() {
-		return userDTO.getName();
-	}
-
 	public String getProviderId() {
 		return userDTO.getProviderId();
-	}
-
-	public String getProvider() {
-		return userDTO.getProvider();
-	}
-
-	public String getEmail() {
-		return userDTO.getEmail();
 	}
 }

--- a/src/main/java/com/gotogether/global/oauth/dto/FirstLoginResponseDTO.java
+++ b/src/main/java/com/gotogether/global/oauth/dto/FirstLoginResponseDTO.java
@@ -1,0 +1,13 @@
+package com.gotogether.global.oauth.dto;
+
+import com.gotogether.domain.user.dto.response.UserDetailResponseDTO;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FirstLoginResponseDTO {
+	private UserDetailResponseDTO user;
+	private String redirect;
+}

--- a/src/main/java/com/gotogether/global/oauth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/gotogether/global/oauth/handler/CustomSuccessHandler.java
@@ -15,6 +15,7 @@ import com.gotogether.global.apipayload.ApiResponse;
 import com.gotogether.global.apipayload.code.status.ErrorStatus;
 import com.gotogether.global.apipayload.exception.GeneralException;
 import com.gotogether.global.oauth.dto.CustomOAuth2User;
+import com.gotogether.global.oauth.dto.FirstLoginResponseDTO;
 import com.gotogether.global.oauth.dto.TokenDTO;
 import com.gotogether.global.oauth.util.JWTUtil;
 import com.gotogether.global.util.CookieUtil;
@@ -62,20 +63,23 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	}
 
 	private void handleFirstLogin(HttpServletResponse response, User user) throws IOException {
-		UserDetailResponseDTO dto = UserDetailResponseDTO.builder()
+		UserDetailResponseDTO userDto = UserDetailResponseDTO.builder()
 			.id(user.getId())
 			.name(user.getName())
 			.email(user.getEmail())
 			.build();
 
-		ApiResponse<UserDetailResponseDTO> apiResponse = ApiResponse.onSuccess(dto);
+		FirstLoginResponseDTO dto = FirstLoginResponseDTO.builder()
+			.user(userDto)
+			.redirect("/join/agreement")
+			.build();
+
+		ApiResponse<FirstLoginResponseDTO> apiResponse = ApiResponse.onSuccess(dto);
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
 		response.setContentType("application/json");
 		response.setStatus(HttpServletResponse.SC_OK);
 		response.getWriter().write(jsonResponse);
-
-		response.sendRedirect(redirectUrl + "/join/agreement");
 	}
 
 	private void handleSuccessLogin(HttpServletResponse response, User user) throws IOException {
@@ -88,5 +92,4 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		response.sendRedirect(redirectUrl);
 	}
-
 }

--- a/src/main/java/com/gotogether/global/oauth/util/JWTFilter.java
+++ b/src/main/java/com/gotogether/global/oauth/util/JWTFilter.java
@@ -49,7 +49,7 @@ public class JWTFilter extends OncePerRequestFilter {
 		Map<String, String> tokens = extractTokensFromCookie(request);
 
 		if (tokens.isEmpty() || tokens.get("refreshToken") == null) {
-			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._UNAUTHORIZED);
+			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._TOKEN_NOT_EXISTS);
 			return;
 		}
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#71 
## ♻️ 초기 로그인 시 회원가입을 위한 유저 객체 정보 응답

- 기존 코드에서 유저 객체 응답과 redirectUrl을 동시에 적용하여 유저 객체 응답이 안되는 문제가 발생
- JSON 응답으로 유저 객체와 리다이렉트할 주소를 전달 -> 이후 프론트에서 회원가입 페이지로 리다이렉트


---

## ♻️ getAuthorities()의 응답 객체 수정
<img width="685" alt="image" src="https://github.com/user-attachments/assets/015a0660-c0a0-4f12-9c8a-043c87d736c0" />


</br></br>



```jsx
// SimpleGrantedAuthority.java

public SimpleGrantedAuthority(String role) {
  Assert.hasText(role, "A granted authority textual representation is required");
  this.role = role;
}
```

SimpleGrantedAuthority 객체를 통해 간단한 String 권한을 생성하여 응답

---

## ♻️ getName() `@Override` 하여 유저ID 응답
<img width="330" alt="image" src="https://github.com/user-attachments/assets/f376951c-96fb-4c15-a963-b6536578e558" />

OAuth2User는 OAuth 로그인 사용자의 정보를 표현하는 표준 인터페이스로 사용자를 식별할 수 있는 고유한 식별자를 반환하도록 구현해야 하므로 `유저ID` 값을 응답하도록 수정


## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.