### PR TITLE
[refactor] 티켓 옵션 응답 로직 수정

### DIFF
--- a/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
@@ -24,6 +24,8 @@ import com.gotogether.domain.order.repository.OrderRepository;
 import com.gotogether.domain.ticket.entity.Ticket;
 import com.gotogether.domain.ticket.entity.TicketStatus;
 import com.gotogether.domain.ticket.entity.TicketType;
+import com.gotogether.domain.ticketoptionanswer.entity.TicketOptionAnswer;
+import com.gotogether.domain.ticketoptionanswer.service.TicketOptionAnswerService;
 import com.gotogether.domain.ticketqrcode.entity.TicketQrCode;
 import com.gotogether.domain.ticketqrcode.service.TicketQrCodeService;
 import com.gotogether.domain.user.entity.User;
@@ -40,6 +42,7 @@ public class OrderServiceImpl implements OrderService {
 	private final EventFacade eventFacade;
 	private final TicketQrCodeService ticketQrCodeService;
 	private final OrderCustomRepository orderCustomRepository;
+	private final TicketOptionAnswerService ticketOptionAnswerService;
 
 	@Override
 	@Transactional
@@ -51,8 +54,15 @@ public class OrderServiceImpl implements OrderService {
 		checkTicketAvailableQuantity(ticket, ticketCnt);
 		checkTicketStatus(ticket);
 
+		List<TicketOptionAnswer> answers = ticketOptionAnswerService.getPendingAnswersByTicket(ticket);
+
 		return IntStream.range(0, ticketCnt)
-			.mapToObj(i -> createTicketOrder(user, ticket))
+			.mapToObj(i -> {
+				Order order = createTicketOrder(user, ticket);
+				TicketOptionAnswer answer = answers.get(i);
+				answer.assignOrder(order);
+				return order;
+			})
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/controller/TicketOptionAnswerController.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/controller/TicketOptionAnswerController.java
@@ -21,9 +21,8 @@ public class TicketOptionAnswerController {
 
 	@PostMapping
 	public ApiResponse<?> createTicketOptionAnswer(
-		@AuthUser Long userId,
 		@RequestBody TicketOptionAnswerRequestDTO request) {
-		ticketOptionAnswerService.createTicketOptionAnswer(userId, request);
+		ticketOptionAnswerService.createTicketOptionAnswer(request);
 		return ApiResponse.onSuccess("티켓 옵션 응답 등록 완료");
 	}
 }

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/entity/TicketOptionAnswer.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/entity/TicketOptionAnswer.java
@@ -3,6 +3,7 @@ package com.gotogether.domain.ticketoptionanswer.entity;
 import com.gotogether.domain.order.entity.Order;
 import com.gotogether.domain.ticketoption.entity.TicketOption;
 import com.gotogether.domain.ticketoption.entity.TicketOptionChoice;
+import com.gotogether.domain.user.entity.User;
 import com.gotogether.global.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -30,7 +31,11 @@ public class TicketOptionAnswer extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "order_id", nullable = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id")
 	private Order order;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -45,8 +50,8 @@ public class TicketOptionAnswer extends BaseEntity {
 	private String answerText;
 
 	@Builder
-	public TicketOptionAnswer(Order order, TicketOption ticketOption, TicketOptionChoice ticketOptionChoice,
-		String answerText) {
+	public TicketOptionAnswer(User user, Order order, TicketOption ticketOption, TicketOptionChoice ticketOptionChoice, String answerText) {
+		this.user = user;
 		this.order = order;
 		this.ticketOption = ticketOption;
 		this.ticketOptionChoice = ticketOptionChoice;

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/entity/TicketOptionAnswer.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/entity/TicketOptionAnswer.java
@@ -3,7 +3,6 @@ package com.gotogether.domain.ticketoptionanswer.entity;
 import com.gotogether.domain.order.entity.Order;
 import com.gotogether.domain.ticketoption.entity.TicketOption;
 import com.gotogether.domain.ticketoption.entity.TicketOptionChoice;
-import com.gotogether.domain.user.entity.User;
 import com.gotogether.global.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -31,10 +30,6 @@ public class TicketOptionAnswer extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
-
-	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "order_id")
 	private Order order;
 
@@ -50,11 +45,14 @@ public class TicketOptionAnswer extends BaseEntity {
 	private String answerText;
 
 	@Builder
-	public TicketOptionAnswer(User user, Order order, TicketOption ticketOption, TicketOptionChoice ticketOptionChoice, String answerText) {
-		this.user = user;
+	public TicketOptionAnswer(Order order, TicketOption ticketOption, TicketOptionChoice ticketOptionChoice, String answerText) {
 		this.order = order;
 		this.ticketOption = ticketOption;
 		this.ticketOptionChoice = ticketOptionChoice;
 		this.answerText = answerText;
+	}
+
+	public void assignOrder(Order order) {
+		this.order = order;
 	}
 }

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/repository/TicketOptionAnswerRepository.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/repository/TicketOptionAnswerRepository.java
@@ -1,5 +1,7 @@
 package com.gotogether.domain.ticketoptionanswer.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,6 @@ import com.gotogether.domain.ticketoptionanswer.entity.TicketOptionAnswer;
 
 @Repository
 public interface TicketOptionAnswerRepository extends JpaRepository<TicketOptionAnswer, Long> {
+
+	List<TicketOptionAnswer> findByTicketOptionIdInAndOrderIsNull(List<Long> ticketOptionIds);
 }

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerService.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerService.java
@@ -1,8 +1,14 @@
 package com.gotogether.domain.ticketoptionanswer.service;
 
+import java.util.List;
+
+import com.gotogether.domain.ticket.entity.Ticket;
 import com.gotogether.domain.ticketoptionanswer.dto.request.TicketOptionAnswerRequestDTO;
+import com.gotogether.domain.ticketoptionanswer.entity.TicketOptionAnswer;
 
 public interface TicketOptionAnswerService {
 
-	void createTicketOptionAnswer(Long userId, TicketOptionAnswerRequestDTO request);
+	void createTicketOptionAnswer(TicketOptionAnswerRequestDTO request);
+
+	List<TicketOptionAnswer> getPendingAnswersByTicket(Ticket ticket);
 }

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerServiceImpl.java
@@ -2,8 +2,6 @@ package com.gotogether.domain.ticketoptionanswer.service;
 
 import org.springframework.stereotype.Service;
 
-import com.gotogether.domain.order.entity.Order;
-import com.gotogether.domain.order.repository.OrderRepository;
 import com.gotogether.domain.ticketoption.entity.TicketOption;
 import com.gotogether.domain.ticketoption.entity.TicketOptionChoice;
 import com.gotogether.domain.ticketoption.repository.TicketOptionChoiceRepository;
@@ -12,17 +10,22 @@ import com.gotogether.domain.ticketoptionanswer.dto.request.TicketOptionAnswerRe
 import com.gotogether.domain.ticketoptionanswer.entity.TicketOptionAnswer;
 import com.gotogether.domain.ticketoptionanswer.repository.TicketOptionAnswerRepository;
 import com.gotogether.domain.ticketoptionassignment.repository.TicketOptionAssignmentRepository;
+import com.gotogether.domain.user.entity.User;
+import com.gotogether.domain.user.repository.UserRepository;
 import com.gotogether.global.apipayload.code.status.ErrorStatus;
 import com.gotogether.global.apipayload.exception.GeneralException;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * TODO: 결제 완료 후, 티켓 옵션에 대한 답변을 OrderId로 연결
+ */
 @Service
 @RequiredArgsConstructor
 public class TicketOptionAnswerServiceImpl implements TicketOptionAnswerService {
 
-	private final OrderRepository orderRepository;
+	private final UserRepository userRepository;
 	private final TicketOptionRepository ticketOptionRepository;
 	private final TicketOptionChoiceRepository ticketOptionChoiceRepository;
 	private final TicketOptionAnswerRepository ticketOptionAnswerRepository;
@@ -31,14 +34,10 @@ public class TicketOptionAnswerServiceImpl implements TicketOptionAnswerService 
 	@Override
 	@Transactional
 	public void createTicketOptionAnswer(Long userId, TicketOptionAnswerRequestDTO request) {
+		User user = getUser(userId);
+
 		TicketOption ticketOption = ticketOptionRepository.findById(request.getTicketOptionId())
 			.orElseThrow(() -> new GeneralException(ErrorStatus._TICKET_OPTION_NOT_FOUND));
-
-		Order order = orderRepository.findCompletedOrdersByUserId(userId).stream()
-			.filter(o -> ticketOptionAssignmentRepository.findAllByTicket(o.getTicket()).stream()
-				.anyMatch(assignment -> assignment.getTicketOption().getId().equals(ticketOption.getId())))
-			.findFirst()
-			.orElseThrow(() -> new GeneralException(ErrorStatus._ORDER_NOT_FOUND));
 
 		TicketOptionChoice choice = null;
 		if (ticketOption.isSelectableType() && request.getTicketOptionChoiceId() != null) {
@@ -47,12 +46,17 @@ public class TicketOptionAnswerServiceImpl implements TicketOptionAnswerService 
 		}
 
 		TicketOptionAnswer answer = TicketOptionAnswer.builder()
-			.order(order)
+			.user(user)
 			.ticketOption(ticketOption)
 			.ticketOptionChoice(choice)
 			.answerText(request.getAnswerText())
 			.build();
 
 		ticketOptionAnswerRepository.save(answer);
+	}
+
+	private User getUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 	}
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
티켓 옵션 응답 로직 수정

## PR
어떤 변경 사항이 있나요?
- 사용자가 티켓 옵션 응답을 먼저 생성하고, 결제하는 흐름으로 로직 수정
- 주문 생성 시, 옵션 응답과 주문 ID 매핑 기능 구현
  - 하나의 티켓을 여러 개 구매할 경우, 여러 개의 Order 엔티티가 생성되는데, 이에 따라 미연결된 티켓 옵션 응답을 각각의 주문에 순차적으로 할당하도록 로직을 구현했습니다. 
---

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.