### PR TITLE
[refactor] ticketId에 대한 티켓 옵션 조회로 수정

### DIFF
--- a/src/main/java/com/gotogether/domain/ticketoption/controller/TicketOptionController.java
+++ b/src/main/java/com/gotogether/domain/ticketoption/controller/TicketOptionController.java
@@ -9,15 +9,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.gotogether.domain.ticketoption.dto.request.TicketOptionRequestDTO;
-import com.gotogether.domain.ticketoption.dto.response.TicketOptionPerTicketResponseDTO;
 import com.gotogether.domain.ticketoption.dto.response.TicketOptionDetailResponseDTO;
 import com.gotogether.domain.ticketoption.entity.TicketOption;
 import com.gotogether.domain.ticketoption.service.TicketOptionService;
-import com.gotogether.global.annotation.AuthUser;
 import com.gotogether.global.apipayload.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -36,18 +33,18 @@ public class TicketOptionController {
 		return ApiResponse.onSuccessCreated("ticketOptionId: " + ticketOption.getId());
 	}
 
-	@GetMapping
+	@GetMapping("/events/{eventId}")
 	public ApiResponse<List<TicketOptionDetailResponseDTO>> getTicketOptionsByEventId(
-		@RequestParam Long eventId) {
+		@PathVariable Long eventId) {
 		List<TicketOptionDetailResponseDTO> ticketOptions = ticketOptionService.getTicketOptionsByEventId(eventId);
 		return ApiResponse.onSuccess(ticketOptions);
 	}
 
-	@GetMapping("/me")
-	public ApiResponse<List<TicketOptionPerTicketResponseDTO>> getTicketOptionsPerTicket(
-		@AuthUser Long userId) {
-		List<TicketOptionPerTicketResponseDTO> ticketOptionPerTicketList = ticketOptionService.getTicketOptionsPerTicket(userId);
-		return ApiResponse.onSuccess(ticketOptionPerTicketList);
+	@GetMapping("/tickets/{ticketId}")
+	public ApiResponse<List<TicketOptionDetailResponseDTO>> getTicketOptionsByTicketId(
+		@PathVariable Long ticketId) {
+		List<TicketOptionDetailResponseDTO> ticketOptions = ticketOptionService.getTicketOptionsByTicketId(ticketId);
+		return ApiResponse.onSuccess(ticketOptions);
 	}
 
 	@GetMapping("/{ticketOptionId}")

--- a/src/main/java/com/gotogether/domain/ticketoption/service/TicketOptionService.java
+++ b/src/main/java/com/gotogether/domain/ticketoption/service/TicketOptionService.java
@@ -3,7 +3,6 @@ package com.gotogether.domain.ticketoption.service;
 import java.util.List;
 
 import com.gotogether.domain.ticketoption.dto.request.TicketOptionRequestDTO;
-import com.gotogether.domain.ticketoption.dto.response.TicketOptionPerTicketResponseDTO;
 import com.gotogether.domain.ticketoption.dto.response.TicketOptionDetailResponseDTO;
 import com.gotogether.domain.ticketoption.entity.TicketOption;
 
@@ -13,7 +12,7 @@ public interface TicketOptionService {
 
 	List<TicketOptionDetailResponseDTO> getTicketOptionsByEventId(Long eventId);
 
-	List<TicketOptionPerTicketResponseDTO> getTicketOptionsPerTicket(Long userId);
+	List<TicketOptionDetailResponseDTO> getTicketOptionsByTicketId(Long ticketId);
 
 	TicketOptionDetailResponseDTO getTicketOption(Long ticketOptionId);
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
ticketId에 대한 티켓 옵션 조회로 수정

## PR
어떤 변경 사항이 있나요?

### ⭐️ ticketId에 대한 티켓 옵션 조회
- 특정 ticketId에 연결된 옵션 목록을 조회하도록 로직 변경
- `/api/v1/ticket-options/me` -> `/api/v1/ticket-options/tickets/{ticketId}`로 엔드포인트 변경

### ⭐️ eventId에 대한 티켓 옵션 조회 (추가 수정)
-  `/api/v1/ticket-options` -> `/api/v1/ticket-options/events/{eventId}`로 엔드포인트 변경

---

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.