### PR TITLE
[fix] 이벤트 삭제 시 외래키 데이터 삭제 안되는 문제 수정

### DIFF
--- a/src/main/java/com/gotogether/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/gotogether/domain/event/converter/EventConverter.java
@@ -77,6 +77,7 @@ public class EventConverter {
 			.title(event.getTitle())
 			.hostChannelName(event.getHostChannel().getName())
 			.startDate(String.valueOf(event.getStartDate()))
+			.endDate(String.valueOf(event.getEndDate()))
 			.address(event.getAddress())
 			.onlineType(String.valueOf(event.getOnlineType()))
 			.hashtags(event.getHashtags().stream()

--- a/src/main/java/com/gotogether/domain/event/dto/response/EventListResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/event/dto/response/EventListResponseDTO.java
@@ -13,6 +13,7 @@ public class EventListResponseDTO {
 	private String title;
 	private String hostChannelName;
 	private String startDate;
+	private String endDate;
 	private String address;
 	private String onlineType;
 	private List<String> hashtags;

--- a/src/main/java/com/gotogether/domain/event/entity/EventStatus.java
+++ b/src/main/java/com/gotogether/domain/event/entity/EventStatus.java
@@ -1,5 +1,5 @@
 package com.gotogether.domain.event.entity;
 
 public enum EventStatus {
-	PROGRESS, COMPLETED
+	PROGRESS, COMPLETED, DELETED
 }

--- a/src/main/java/com/gotogether/domain/event/repository/EventCustomRepositoryImpl.java
+++ b/src/main/java/com/gotogether/domain/event/repository/EventCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.gotogether.domain.event.entity.Event;
+import com.gotogether.domain.event.entity.EventStatus;
 import com.gotogether.domain.event.entity.QEvent;
 import com.gotogether.domain.eventhashtag.entity.QEventHashtag;
 import com.gotogether.domain.hashtag.entity.QHashtag;
@@ -37,7 +38,8 @@ public class EventCustomRepositoryImpl implements EventCustomRepository {
 		QEventHashtag eventHashtag = QEventHashtag.eventHashtag;
 		QHashtag hashtag = QHashtag.hashtag;
 
-		BooleanExpression baseCondition = event.endDate.goe(LocalDateTime.now());
+		BooleanExpression baseCondition = event.endDate.goe(LocalDateTime.now())
+			.and(event.status.ne(EventStatus.DELETED));
 
 		List<Long> eventIds = queryFactory
 			.select(event.id)

--- a/src/main/java/com/gotogether/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/gotogether/domain/event/repository/EventRepository.java
@@ -22,6 +22,13 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 		""")
 	Page<Event> findEventsByFilter(@Param("keyword") String keyword, Pageable pageable);
 
+	@Query("""
+			SELECT e FROM Event e
+			WHERE e.category = :category
+				AND e.endDate >= CURRENT_TIMESTAMP
+				AND e.status != 'DELETED'
+			ORDER BY e.createdAt DESC
+		""")
 	Page<Event> findByCategory(Category category, Pageable pageable);
 
 	long countByHostChannel(HostChannel hostChannel);

--- a/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
@@ -105,7 +105,7 @@ public class EventServiceImpl implements EventService {
 		hashtagService.deleteHashtagsByEvent(event);
 
 		eventScheduler.deleteScheduledEventJob(eventId);
-		eventRepository.delete(event);
+		event.updateStatus(EventStatus.DELETED);
 	}
 
 	@Override

--- a/src/main/java/com/gotogether/domain/hostchannel/converter/HostChannelConverter.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/converter/HostChannelConverter.java
@@ -80,6 +80,7 @@ public class HostChannelConverter {
 			.phoneNumber(order.getUser().getPhoneNumber())
 			.purchaseDate(String.valueOf(order.getCreatedAt()))
 			.ticketName(order.getTicket().getName())
+			.ticketType(order.getTicket().getType().name())
 			.isCheckedIn(order.getTicketQrCode() != null && order.getTicketQrCode().getStatus().isCheckIn())
 			.isApproved(order.getStatus() == OrderStatus.COMPLETED)
 			.build();

--- a/src/main/java/com/gotogether/domain/hostchannel/converter/HostChannelConverter.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/converter/HostChannelConverter.java
@@ -15,6 +15,7 @@ import com.gotogether.domain.hostchannel.dto.response.HostDashboardResponseDTO;
 import com.gotogether.domain.hostchannel.dto.response.ParticipantManagementResponseDTO;
 import com.gotogether.domain.hostchannel.entity.HostChannel;
 import com.gotogether.domain.order.entity.Order;
+import com.gotogether.domain.order.entity.OrderStatus;
 
 public class HostChannelConverter {
 
@@ -80,7 +81,7 @@ public class HostChannelConverter {
 			.purchaseDate(String.valueOf(order.getCreatedAt()))
 			.ticketName(order.getTicket().getName())
 			.isCheckedIn(order.getTicketQrCode() != null && order.getTicketQrCode().getStatus().isCheckIn())
-			.orderStatus(order.getStatus().name())
+			.isApproved(order.getStatus() == OrderStatus.COMPLETED)
 			.build();
 	}
 

--- a/src/main/java/com/gotogether/domain/hostchannel/dto/response/ParticipantManagementResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/dto/response/ParticipantManagementResponseDTO.java
@@ -15,5 +15,5 @@ public class ParticipantManagementResponseDTO {
 	private String purchaseDate;
 	private String ticketName;
 	private boolean isCheckedIn;
-	private String orderStatus;
+	private boolean isApproved;
 }

--- a/src/main/java/com/gotogether/domain/hostchannel/dto/response/ParticipantManagementResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/dto/response/ParticipantManagementResponseDTO.java
@@ -14,6 +14,7 @@ public class ParticipantManagementResponseDTO {
 	private String phoneNumber;
 	private String purchaseDate;
 	private String ticketName;
+	private String ticketType;
 	private boolean isCheckedIn;
 	private boolean isApproved;
 }

--- a/src/main/java/com/gotogether/domain/order/controller/OrderController.java
+++ b/src/main/java/com/gotogether/domain/order/controller/OrderController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.gotogether.domain.order.dto.request.OrderCancelRequestDTO;
 import com.gotogether.domain.order.dto.request.OrderRequestDTO;
 import com.gotogether.domain.order.dto.response.OrderInfoResponseDTO;
 import com.gotogether.domain.order.dto.response.OrderedTicketResponseDTO;
@@ -61,11 +62,11 @@ public class OrderController {
 		return ApiResponse.onSuccess(orderService.getPurchaseConfirmation(orderId));
 	}
 
-	@PostMapping("/{orderId}/cancel")
+	@PostMapping("/cancel")
 	public ApiResponse<?> cancelOrder(
 		@AuthUser Long userId,
-		@PathVariable("orderId") Long orderId) {
-		orderService.cancelOrder(userId, orderId);
+		@RequestBody OrderCancelRequestDTO request) {
+		orderService.cancelOrder(request, userId);
 		return ApiResponse.onSuccess("주문 취소 성공");
 	}
 

--- a/src/main/java/com/gotogether/domain/order/dto/request/OrderCancelRequestDTO.java
+++ b/src/main/java/com/gotogether/domain/order/dto/request/OrderCancelRequestDTO.java
@@ -1,0 +1,16 @@
+package com.gotogether.domain.order.dto.request;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderCancelRequestDTO {
+	private List<Long> orderIds;
+}

--- a/src/main/java/com/gotogether/domain/order/service/OrderService.java
+++ b/src/main/java/com/gotogether/domain/order/service/OrderService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.gotogether.domain.order.dto.request.OrderCancelRequestDTO;
 import com.gotogether.domain.order.dto.request.OrderRequestDTO;
 import com.gotogether.domain.order.dto.response.OrderInfoResponseDTO;
 import com.gotogether.domain.order.dto.response.OrderedTicketResponseDTO;
@@ -18,7 +19,7 @@ public interface OrderService {
 
 	OrderInfoResponseDTO getPurchaseConfirmation(Long orderId);
 
-	void cancelOrder(Long userId, Long orderId);
+	void cancelOrder(OrderCancelRequestDTO request, Long userId);
 
 	TicketPurchaserEmailResponseDTO getPurchaserEmails(Long eventId, Long ticketId);
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🐞 이벤트 삭제 시 외래 키 제약 조건 오류 수정
- `Event` 엔티티에 `EventStatus` DELETED 추가 
- 이벤트 삭제 시 `EventStatus` DELETED로 업데이트

### Issue외 작업 사항
-  카테고리별 이벤트 조회 삭제된 이벤트 안보이게 수정
- 이벤트 전체 조회 삭제된 이벤트 안보이게 수정
- 구매 참가자 관리 조회 승인 여부 boolean으로 수정 (OrderStatus -> isApproved)
- 이벤트 리스트 조회 `EndDate` 필드 추가
- 구매 참가자 관리 조회 `ticketType` 필드 추가
- 주문 취소 Reqeust 배열로 수정


## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.