### PR TITLE
[refactor] 사용자 응답 전체 조회 시, 응답 DTO 주문 개수 추가

### DIFF
--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/controller/TicketOptionAnswerController.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/controller/TicketOptionAnswerController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.gotogether.domain.ticketoptionanswer.dto.request.TicketOptionAnswerRequestDTO;
 import com.gotogether.domain.ticketoptionanswer.dto.response.PurchaserAnswerDetailResponseDTO;
-import com.gotogether.domain.ticketoptionanswer.dto.response.PurchaserAnswerResponseDTO;
+import com.gotogether.domain.ticketoptionanswer.dto.response.PurchaserAnswerListResponseDTO;
 import com.gotogether.domain.ticketoptionanswer.service.TicketOptionAnswerService;
 import com.gotogether.global.annotation.AuthUser;
 import com.gotogether.global.apipayload.ApiResponse;
@@ -41,9 +41,9 @@ public class TicketOptionAnswerController {
 	}
 
 	@GetMapping("/purchaser-answer")
-	public ApiResponse<List<PurchaserAnswerResponseDTO>> getPurchaserAnswers(
+	public ApiResponse<PurchaserAnswerListResponseDTO> getPurchaserAnswers(
 		@RequestParam Long ticketId) {
-		List<PurchaserAnswerResponseDTO> answers = ticketOptionAnswerService.getPurchaserAnswers(ticketId);
+		PurchaserAnswerListResponseDTO answers = ticketOptionAnswerService.getPurchaserAnswers(ticketId);
 		return ApiResponse.onSuccess(answers);
 	}
 }

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/converter/TicketOptionAnswerConverter.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/converter/TicketOptionAnswerConverter.java
@@ -47,7 +47,7 @@ public class TicketOptionAnswerConverter {
 			.optionId(ticketOption.getId())
 			.optionName(ticketOption.getName())
 			.optionType(ticketOption.getType().name())
-			.answers(response)
+			.ticketOptionAnswers(response)
 			.build();
 	}
 

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/dto/response/PurchaserAnswerListResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/dto/response/PurchaserAnswerListResponseDTO.java
@@ -1,0 +1,15 @@
+package com.gotogether.domain.ticketoptionanswer.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PurchaserAnswerListResponseDTO {
+
+	private int orderCount;
+
+	private List<PurchaserAnswerResponseDTO> ticketOptions;
+}

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/dto/response/PurchaserAnswerResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/dto/response/PurchaserAnswerResponseDTO.java
@@ -15,5 +15,5 @@ public class PurchaserAnswerResponseDTO {
 
 	private String optionType;
 
-	private List<TicketOptionAnswerResponseDTO> answers;
+	private List<TicketOptionAnswerResponseDTO> ticketOptionAnswers;
 }

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerService.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerService.java
@@ -6,7 +6,7 @@ import com.gotogether.domain.order.entity.Order;
 import com.gotogether.domain.ticket.entity.Ticket;
 import com.gotogether.domain.ticketoptionanswer.dto.request.TicketOptionAnswerRequestDTO;
 import com.gotogether.domain.ticketoptionanswer.dto.response.PurchaserAnswerDetailResponseDTO;
-import com.gotogether.domain.ticketoptionanswer.dto.response.PurchaserAnswerResponseDTO;
+import com.gotogether.domain.ticketoptionanswer.dto.response.PurchaserAnswerListResponseDTO;
 import com.gotogether.domain.ticketoptionanswer.entity.TicketOptionAnswer;
 import com.gotogether.domain.user.entity.User;
 
@@ -18,7 +18,7 @@ public interface TicketOptionAnswerService {
 
 	List<PurchaserAnswerDetailResponseDTO> getAnswersByTicket(Long ticketId);
 
-	List<PurchaserAnswerResponseDTO> getPurchaserAnswers(Long ticketId);
+	PurchaserAnswerListResponseDTO getPurchaserAnswers(Long ticketId);
 
 	void createTicketOptionAnswers(User user, List<TicketOptionAnswerRequestDTO> requests, Order order);
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
사용자 응답 전체 조회 시, 응답 DTO 주문 개수 추가

## PR
어떤 변경 사항이 있나요?
### ⭐️사용자 응답 전체 조회 시, 응답 DTO 주문 개수(`orderCount`) 추가
<img width="711" alt="스크린샷 2025-05-30 오전 2 08 48" src="https://github.com/user-attachments/assets/39a90e72-dc73-4dde-b0f3-ea66881d9a68" />

---

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.