### PR TITLE
[fix] jib 빌드 한국 시간 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ jacocoTestCoverageVerification {
 
 jib {
     from {
-        image = 'openjdk:17-alpine'
+        image = 'openjdk:17'
         platforms {
             platform {
                 architecture = 'amd64'
@@ -135,5 +135,9 @@ jib {
     }
     to {
         image = 'zmflspa123/gotogether:latest'
+    }
+    container {
+        environment = [ 'TZ': 'Asia/Seoul' ]
+        jvmFlags = ['-Duser.timezone=Asia/Seoul']
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🐞수정사항
- jib 빌드 이미지 `openjdk:17` 로 변경
- 한국 시간 적용을 위해 timezone = Asis/Seoul 설정

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.