### PR TITLE
[fix] 호스트 개별 조회 시, 삭제된 이벤트가 조회되는 문제 해결

### DIFF
--- a/src/main/java/com/gotogether/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/gotogether/domain/event/repository/EventRepository.java
@@ -1,5 +1,7 @@
 package com.gotogether.domain.event.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,4 +34,12 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 	Page<Event> findByCategory(Category category, Pageable pageable);
 
 	long countByHostChannel(HostChannel hostChannel);
+
+	@Query("""
+		SELECT e FROM Event e
+		WHERE e.hostChannel.id = :hostChannelId
+		AND e.status != 'DELETED'
+		ORDER BY e.createdAt DESC
+		""")
+	List<Event> findAllByHostChannelId(@Param("hostChannelId") Long hostChannelId);
 }

--- a/src/main/java/com/gotogether/domain/hostchannel/converter/HostChannelConverter.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/converter/HostChannelConverter.java
@@ -36,8 +36,8 @@ public class HostChannelConverter {
 			.build();
 	}
 
-	public static HostChannelDetailResponseDTO toHostChannelDetailResponseDTO(HostChannel hostChannel) {
-		List<EventListResponseDTO> eventListResponseDTOList = hostChannel.getEvents().stream()
+	public static HostChannelDetailResponseDTO toHostChannelDetailResponseDTO(HostChannel hostChannel, List<Event> events) {
+		List<EventListResponseDTO> eventListResponseDTOList = events.stream()
 			.map(EventConverter::toEventListResponseDTO)
 			.toList();
 

--- a/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
@@ -97,9 +97,12 @@ public class HostChannelServiceImpl implements HostChannelService {
 	@Override
 	@Transactional(readOnly = true)
 	public HostChannelDetailResponseDTO getDetailHostChannel(Long hostChannelId) {
-		HostChannel hostChannel = eventFacade.getHostChannelById(hostChannelId);
+		HostChannel hostChannel = hostChannelRepository.findById(hostChannelId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._HOST_CHANNEL_NOT_FOUND));
 
-		return HostChannelConverter.toHostChannelDetailResponseDTO(hostChannel);
+		List<Event> events = eventRepository.findAllByHostChannelId(hostChannelId);
+
+		return HostChannelConverter.toHostChannelDetailResponseDTO(hostChannel, events);
 	}
 
 	@Override

--- a/src/main/java/com/gotogether/domain/order/converter/OrderConverter.java
+++ b/src/main/java/com/gotogether/domain/order/converter/OrderConverter.java
@@ -36,7 +36,7 @@ public class OrderConverter {
 		EventListResponseDTO eventListDTO = EventConverter.toEventListResponseDTO(event);
 
 		return OrderedTicketResponseDTO.builder()
-			.id(order.getId())
+			.orderId(order.getId())
 			.event(eventListDTO)
 			.ticketQrCode(ticketQrCode != null ? ticketQrCode.getQrCodeImageUrl() : null)
 			.ticketName(ticket.getName())

--- a/src/main/java/com/gotogether/domain/order/dto/response/OrderedTicketResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/order/dto/response/OrderedTicketResponseDTO.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class OrderedTicketResponseDTO {
-	private Long id;
+	private Long orderId;
 	private EventListResponseDTO event;
 	private String ticketQrCode;
 	private String ticketName;


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
호스트 개별 조회 시, 삭제된 이벤트가 조회되는 문제 해결

## PR
어떤 변경 사항이 있나요?

### ⭐️ 호스트 개별 조회 시, 삭제된 이벤트가 조회되는 문제 해결
- 호스트 채널과 삭제되지 않은 이벤트 목록을 각각 조회한 뒤, 이를 DTO로 변환하여 삭제된 이벤트가 포함되지 않도록 해결

### ✨ Issue외 작업 사항
- 내 구매 티켓 조회 시, `orderId` 응답 필드명 변경

---
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.