### PR TITLE
[refactor] 이벤트 상세 조회, 내 주문 조회, 호스트 채널 상세 조회 쿼리 최적화

### DIFF
--- a/src/main/java/com/gotogether/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/gotogether/domain/event/converter/EventConverter.java
@@ -34,7 +34,7 @@ public class EventConverter {
 			.build();
 	}
 
-	public static EventDetailResponseDTO toEventDetailResponseDTO(Event event, Long bookmarkId) {
+	public static EventDetailResponseDTO toEventDetailResponseDTO(Event event, Long participantCount, Long bookmarkId) {
 		List<ReferenceLinkDTO> links = event.getReferenceLinks().stream()
 			.map(link -> ReferenceLinkDTO.builder()
 				.title(link.getName())
@@ -46,7 +46,7 @@ public class EventConverter {
 			.id(event.getId())
 			.bannerImageUrl(event.getBannerImageUrl())
 			.title(event.getTitle())
-			.participantCount(event.getTickets().size())
+			.participantCount(participantCount)
 			.startDate(String.valueOf(event.getStartDate()))
 			.endDate(String.valueOf(event.getEndDate()))
 			.address(event.getAddress())
@@ -62,9 +62,6 @@ public class EventConverter {
 			.category(String.valueOf(event.getCategory()))
 			.onlineType(String.valueOf(event.getOnlineType()))
 			.status(String.valueOf(event.getStatus()))
-			.hashtags(event.getHashtags().stream()
-				.map(Hashtag::getName)
-				.collect(Collectors.toList()))
 			.bookmarkId(bookmarkId)
 			.isBookmarked(bookmarkId != null)
 			.build();

--- a/src/main/java/com/gotogether/domain/event/dto/response/EventDetailResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/event/dto/response/EventDetailResponseDTO.java
@@ -13,7 +13,7 @@ public class EventDetailResponseDTO {
 	private Long id;
 	private String bannerImageUrl;
 	private String title;
-	private int participantCount;
+	private Long participantCount;
 	private String startDate;
 	private String endDate;
 	private String address;
@@ -29,7 +29,6 @@ public class EventDetailResponseDTO {
 	private String category;
 	private String onlineType;
 	private String status;
-	private List<String> hashtags;
 	private Long bookmarkId;
 	private boolean isBookmarked;
 }

--- a/src/main/java/com/gotogether/domain/event/repository/EventCustomRepositoryImpl.java
+++ b/src/main/java/com/gotogether/domain/event/repository/EventCustomRepositoryImpl.java
@@ -15,7 +15,6 @@ import com.gotogether.domain.event.entity.QEvent;
 import com.gotogether.domain.eventhashtag.entity.QEventHashtag;
 import com.gotogether.domain.hashtag.entity.QHashtag;
 import com.gotogether.domain.hostchannel.entity.QHostChannel;
-import com.gotogether.domain.referencelink.entity.QReferenceLink;
 import com.gotogether.domain.ticket.entity.QTicket;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -72,20 +71,15 @@ public class EventCustomRepositoryImpl implements EventCustomRepository {
 	public Optional<Event> findEventWithDetails(Long eventId) {
 		QEvent event = QEvent.event;
 		QHostChannel hostChannel = QHostChannel.hostChannel;
-		QTicket ticket = QTicket.ticket;
-		QReferenceLink referenceLink = QReferenceLink.referenceLink;
 		QEventHashtag eventHashtag = QEventHashtag.eventHashtag;
 		QHashtag hashtag = QHashtag.hashtag;
 
 		Event result = queryFactory
-			.selectFrom(event)
+			.selectFrom(event).distinct()
 			.leftJoin(event.hostChannel, hostChannel).fetchJoin()
-			.leftJoin(event.tickets, ticket)
-			.leftJoin(event.referenceLinks, referenceLink)
-			.leftJoin(event.eventHashtags, eventHashtag)
-			.leftJoin(eventHashtag.hashtag, hashtag)
+			.leftJoin(event.eventHashtags, eventHashtag).fetchJoin()
+			.leftJoin(eventHashtag.hashtag, hashtag).fetchJoin()
 			.where(event.id.eq(eventId))
-			.distinct()
 			.fetchOne();
 
 		return Optional.ofNullable(result);

--- a/src/main/java/com/gotogether/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/gotogether/domain/event/repository/EventRepository.java
@@ -36,7 +36,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 	long countByHostChannel(HostChannel hostChannel);
 
 	@Query("""
-		SELECT e FROM Event e
+		SELECT DISTINCT e FROM Event e
+		LEFT JOIN FETCH e.eventHashtags eh
+		LEFT JOIN FETCH eh.hashtag
 		WHERE e.hostChannel.id = :hostChannelId
 		AND e.status != 'DELETED'
 		ORDER BY e.createdAt DESC

--- a/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
@@ -19,6 +19,7 @@ import com.gotogether.domain.event.repository.EventCustomRepository;
 import com.gotogether.domain.event.repository.EventRepository;
 import com.gotogether.domain.hashtag.service.HashtagService;
 import com.gotogether.domain.hostchannel.entity.HostChannel;
+import com.gotogether.domain.order.repository.OrderRepository;
 import com.gotogether.domain.referencelink.service.ReferenceLinkService;
 import com.gotogether.domain.user.entity.User;
 import com.gotogether.global.apipayload.code.status.ErrorStatus;
@@ -35,6 +36,7 @@ public class EventServiceImpl implements EventService {
 	private final EventRepository eventRepository;
 	private final EventCustomRepository eventCustomRepository;
 	private final BookmarkRepository bookmarkRepository;
+	private final OrderRepository orderRepository;
 	private final HashtagService hashtagService;
 	private final ReferenceLinkService referenceLinkService;
 	private final EventScheduler eventScheduler;
@@ -65,6 +67,8 @@ public class EventServiceImpl implements EventService {
 		Event event = eventCustomRepository.findEventWithDetails(eventId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._EVENT_NOT_FOUND));
 
+		Long participantCount = orderRepository.countByEventId(eventId);
+
 		Long bookmarkId = null;
 		if (userId != null) {
 			User user = eventFacade.getUserById(userId);
@@ -74,7 +78,7 @@ public class EventServiceImpl implements EventService {
 				.orElse(null);
 		}
 
-		return EventConverter.toEventDetailResponseDTO(event, bookmarkId);
+		return EventConverter.toEventDetailResponseDTO(event, participantCount, bookmarkId);
 	}
 
 	@Override

--- a/src/main/java/com/gotogether/domain/order/repository/OrderCustomRepositoryImpl.java
+++ b/src/main/java/com/gotogether/domain/order/repository/OrderCustomRepositoryImpl.java
@@ -9,8 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.gotogether.domain.event.entity.QEvent;
-import com.gotogether.domain.eventhashtag.entity.QEventHashtag;
-import com.gotogether.domain.hashtag.entity.QHashtag;
 import com.gotogether.domain.hostchannel.entity.QHostChannel;
 import com.gotogether.domain.order.entity.Order;
 import com.gotogether.domain.order.entity.OrderStatus;
@@ -76,8 +74,6 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
 		QUser qUser = QUser.user;
 		QEvent event = QEvent.event;
 		QHostChannel hostChannel = QHostChannel.hostChannel;
-		QEventHashtag eventHashtag = QEventHashtag.eventHashtag;
-		QHashtag hashtag = QHashtag.hashtag;
 
 		return queryFactory
 			.selectDistinct(order)
@@ -87,8 +83,6 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
 			.join(ticket.event, event).fetchJoin()
 			.join(event.hostChannel, hostChannel).fetchJoin()
 			.leftJoin(order.ticketQrCode, ticketQrCode).fetchJoin()
-			.leftJoin(event.eventHashtags, eventHashtag).fetchJoin()
-			.leftJoin(eventHashtag.hashtag, hashtag).fetchJoin()
 			.where(
 				order.user.eq(user),
 				order.status.ne(OrderStatus.CANCELED)

--- a/src/main/java/com/gotogether/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gotogether/domain/order/repository/OrderRepository.java
@@ -52,4 +52,12 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 	List<Order> findCompletedOrdersByUserId(@Param("userId") Long userId);
 
 	boolean existsByOrderCode(String orderCode);
+
+	@Query("""
+		SELECT COUNT(o)
+		FROM Order o
+		WHERE o.ticket.event.id = :eventId
+		AND o.status <> 'CANCELED'
+		""")
+	Long countByEventId(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/gotogether/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gotogether/domain/order/repository/OrderRepository.java
@@ -42,15 +42,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 		""")
 	List<String> findPurchaserEmailsByTicketId(@Param("ticketId") Long ticketId);
 
-	@Query("""
-		SELECT o
-		FROM Order o
-		JOIN FETCH o.ticket t
-		WHERE o.user.id = :userId
-		AND o.status = 'COMPLETED'
-		""")
-	List<Order> findCompletedOrdersByUserId(@Param("userId") Long userId);
-
 	boolean existsByOrderCode(String orderCode);
 
 	@Query("""

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerService.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerService.java
@@ -3,18 +3,14 @@ package com.gotogether.domain.ticketoptionanswer.service;
 import java.util.List;
 
 import com.gotogether.domain.order.entity.Order;
-import com.gotogether.domain.ticket.entity.Ticket;
 import com.gotogether.domain.ticketoptionanswer.dto.request.TicketOptionAnswerRequestDTO;
 import com.gotogether.domain.ticketoptionanswer.dto.response.PurchaserAnswerDetailResponseDTO;
 import com.gotogether.domain.ticketoptionanswer.dto.response.PurchaserAnswerListResponseDTO;
-import com.gotogether.domain.ticketoptionanswer.entity.TicketOptionAnswer;
 import com.gotogether.domain.user.entity.User;
 
 public interface TicketOptionAnswerService {
 
 	void createTicketOptionAnswer(Long userId, TicketOptionAnswerRequestDTO request);
-
-	List<TicketOptionAnswer> getPendingAnswersByTicket(Ticket ticket);
 
 	List<PurchaserAnswerDetailResponseDTO> getAnswersByTicket(Long ticketId);
 

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/service/TicketOptionAnswerServiceImpl.java
@@ -154,17 +154,6 @@ public class TicketOptionAnswerServiceImpl implements TicketOptionAnswerService 
 	}
 
 	@Override
-	@Transactional(readOnly = true)
-	public List<TicketOptionAnswer> getPendingAnswersByTicket(Ticket ticket) {
-		List<TicketOptionAssignment> assignments = ticketOptionAssignmentRepository.findAllByTicket(ticket);
-		List<Long> ticketOptionIds = assignments.stream()
-			.map(a -> a.getTicketOption().getId())
-			.toList();
-
-		return ticketOptionAnswerRepository.findByTicketOptionIdInAndOrderIsNull(ticketOptionIds);
-	}
-
-	@Override
 	@Transactional
 	public void createTicketOptionAnswers(User user, List<TicketOptionAnswerRequestDTO> requests, Order order) {
 		if (requests == null || requests.isEmpty())


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## ♻️ 리펙토링 사항
- default_batch_szie를 적용

- 이벤트 상세 조회 
    - 단일 Event 조회 후 연관된 `tickets`, `referenceLinks`, `hashtag`을 각각 별도의 쿼리로 조회하는 N+1 문제가 발생
    - `hashtag`은 fetch join, 그 외의 `tickets`, `referenceLinks`은 BatchSize를 통해 배치 조회하도록 최적화
    - 구매자수 로직 수정
    - 해시태그 응답 제거
- 내 주문 조회
    - Event에 연결된 해시태그 수만큼 Order 데이터가 중복 조회되는 카테시안 곱 문제가 발생
    - 기존에 포함되어 있던 `eventHashtags`, `hashtag` join 제거
- 호스트 채널 이벤트 조회
    -  `eventHashtags`, `hashtag` fetch join 추가

### 리팩토링 목적

- 공통적으로 조회 쿼리 내 **fetch join 정리 및 최적화**를 통해
  - 불필요한 DB I/O 줄이기
  - 연관 데이터 로딩을 필요한 만큼으로 제한
  - 쿼리 실행 속도 개선

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.