### PR TITLE
[fix] 배너 이미지 업로드 시 S3에 이미지 남는 문제 해결 

### DIFF
--- a/src/main/java/com/gotogether/domain/event/entity/Event.java
+++ b/src/main/java/com/gotogether/domain/event/entity/Event.java
@@ -152,4 +152,8 @@ public class Event extends BaseEntity {
 	public void updateStatus(EventStatus status) {
 		this.status = status;
 	}
+
+	public void updateBannerImageUrl(String bannerImageUrl) {
+		this.bannerImageUrl = bannerImageUrl;
+	}
 }

--- a/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
@@ -141,14 +141,7 @@ public class EventServiceImpl implements EventService {
 	}
 
 	private void updateBannerImageToFinal(Event event, String imageUrl) {
-		if (imageUrl == null || !imageUrl.contains("temp/")) return;
-
-		String tempKey = s3UploadService.extractKeyFromUrl(imageUrl);
-		String finalKey = tempKey.replace("temp/", "final/");
-		String finalUrl = imageUrl.replace("temp/", "final/");
-
-		s3UploadService.moveFileToFinal(tempKey, finalKey);
-
+		String finalUrl = s3UploadService.moveTempImageToFinal(imageUrl);
 		event.updateBannerImageUrl(finalUrl);
 	}
 }

--- a/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
@@ -85,6 +85,9 @@ public class EventServiceImpl implements EventService {
 	@Transactional
 	public Event updateEvent(Long eventId, EventRequestDTO request) {
 		Event event = eventFacade.getEventById(eventId);
+
+		s3UploadService.deleteFile(event.getBannerImageUrl());
+
 		event.update(request);
 
 		eventRepository.save(event);
@@ -98,6 +101,8 @@ public class EventServiceImpl implements EventService {
 			hashtagService.deleteHashtagsByRequest(event, request.getHashtags());
 			hashtagService.createHashtags(event, request.getHashtags());
 		}
+
+		updateBannerImageToFinal(event, request.getBannerImageUrl());
 
 		return event;
 	}

--- a/src/main/java/com/gotogether/domain/hostchannel/entity/HostChannel.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/entity/HostChannel.java
@@ -73,4 +73,8 @@ public class HostChannel extends BaseEntity {
 		this.description = request.getChannelDescription();
 		this.profileImageUrl = request.getProfileImageUrl();
 	}
+
+	public void updateProfileImageUrl(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
 }

--- a/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
@@ -263,15 +263,7 @@ public class HostChannelServiceImpl implements HostChannelService {
 	}
 
 	private void updateProfileImageToFinal(HostChannel hostChannel, String imageUrl) {
-		if (imageUrl == null || !imageUrl.contains("temp/"))
-			return;
-
-		String tempKey = s3UploadService.extractKeyFromUrl(imageUrl);
-		String finalKey = tempKey.replace("temp/", "final/");
-		String finalUrl = imageUrl.replace("temp/", "final/");
-
-		s3UploadService.moveFileToFinal(tempKey, finalKey);
-
+		String finalUrl = s3UploadService.moveTempImageToFinal(imageUrl);
 		hostChannel.updateProfileImageUrl(finalUrl);
 	}
 }

--- a/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
@@ -136,7 +136,12 @@ public class HostChannelServiceImpl implements HostChannelService {
 	@Transactional
 	public HostChannel updateHostChannel(Long hostChannelId, HostChannelRequestDTO request) {
 		HostChannel hostChannel = eventFacade.getHostChannelById(hostChannelId);
+
+		s3UploadService.deleteFile(hostChannel.getProfileImageUrl());
+
 		hostChannel.update(request);
+
+		updateProfileImageToFinal(hostChannel, request.getProfileImageUrl());
 
 		return hostChannelRepository.save(hostChannel);
 	}

--- a/src/main/java/com/gotogether/global/common/controller/S3UploadAPI.java
+++ b/src/main/java/com/gotogether/global/common/controller/S3UploadAPI.java
@@ -3,6 +3,7 @@ package com.gotogether.global.common.controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.gotogether.global.annotation.AuthUser;
 import com.gotogether.global.apipayload.ApiResponse;
 import com.gotogether.global.common.dto.S3UrlResponseDTO;
 
@@ -14,7 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "FileUpload", description = "파일 업로드 API")
-public interface FileUploadAPI {
+public interface S3UploadAPI {
 
 	@Operation(
 		summary = "S3 Pre-signed URL 생성",
@@ -29,6 +30,7 @@ public interface FileUploadAPI {
 	})
 	@GetMapping("/generate-presigned-url")
 	ApiResponse<S3UrlResponseDTO> generatePresignedUrl(
+		@Parameter(description = "사용자 ID", required = true) @AuthUser Long userId,
 		@Parameter(description = "업로드할 파일명", required = true) @RequestParam String fileName
 	);
 } 

--- a/src/main/java/com/gotogether/global/common/controller/S3UploadController.java
+++ b/src/main/java/com/gotogether/global/common/controller/S3UploadController.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-public class S3UploadController {
+public class S3UploadController implements S3UploadAPI {
 
 	private final S3UploadService s3UploadService;
 

--- a/src/main/java/com/gotogether/global/common/controller/S3UploadController.java
+++ b/src/main/java/com/gotogether/global/common/controller/S3UploadController.java
@@ -1,29 +1,30 @@
 package com.gotogether.global.common.controller;
 
-import java.util.UUID;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.amazonaws.HttpMethod;
+import com.gotogether.global.annotation.AuthUser;
 import com.gotogether.global.apipayload.ApiResponse;
 import com.gotogether.global.common.dto.S3UrlResponseDTO;
-import com.gotogether.global.common.service.FileUploadService;
+import com.gotogether.global.common.service.S3UploadService;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-public class FileUploadController {
+public class S3UploadController {
 
-	private final FileUploadService fileUploadService;
+	private final S3UploadService s3UploadService;
 
 	@GetMapping("/generate-presigned-url")
-	public ApiResponse<S3UrlResponseDTO> generatePresignedUrl(@RequestParam String fileName) {
+	public ApiResponse<S3UrlResponseDTO> generatePresignedUrl(
+		@AuthUser Long userId,
+		@RequestParam String fileName) {
 		return ApiResponse.onSuccess(
-			fileUploadService.generatePreSignUrl(UUID.randomUUID() + fileName, HttpMethod.PUT));
+			s3UploadService.generatePreSignUrl(userId, fileName, HttpMethod.PUT));
 	}
 }

--- a/src/main/java/com/gotogether/global/common/service/S3UploadService.java
+++ b/src/main/java/com/gotogether/global/common/service/S3UploadService.java
@@ -2,6 +2,7 @@ package com.gotogether.global.common.service;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -14,15 +15,15 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class FileUploadService {
+public class S3UploadService {
 
 	@Value("${amazon.aws.bucket}")
 	private String bucketName;
 
 	private final AmazonS3 amazonS3;
 
-	public S3UrlResponseDTO generatePreSignUrl(String filePath,
-		HttpMethod httpMethod) {
+	public S3UrlResponseDTO generatePreSignUrl(Long userId, String fileName, HttpMethod httpMethod) {
+		String filePath = "temp/" + userId + "/" + UUID.randomUUID() + "_" + fileName;
 
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTime(new Date());
@@ -33,6 +34,5 @@ public class FileUploadService {
 		return S3UrlResponseDTO.builder()
 			.preSignedUrl(url)
 			.build();
-
 	}
 }

--- a/src/main/java/com/gotogether/global/common/service/S3UploadService.java
+++ b/src/main/java/com/gotogether/global/common/service/S3UploadService.java
@@ -53,6 +53,13 @@ public class S3UploadService {
 		return finalUrl;
 	}
 
+	public void deleteFile(String imageUrl) {
+		String key = extractKeyFromUrl(imageUrl);
+
+		DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucketName, key);
+		amazonS3.deleteObject(deleteObjectRequest);
+	}
+
 	private String extractKeyFromUrl(String url) {
 		String encodedKey = url.substring(url.indexOf(".com/") + 5);
 		return URLDecoder.decode(encodedKey, StandardCharsets.UTF_8);

--- a/src/main/java/com/gotogether/global/common/service/S3UploadService.java
+++ b/src/main/java/com/gotogether/global/common/service/S3UploadService.java
@@ -13,6 +13,7 @@ import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.gotogether.global.common.dto.S3UrlResponseDTO;
 
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,12 @@ public class S3UploadService {
 		calendar.setTime(new Date());
 		calendar.add(Calendar.MINUTE, 10);
 
-		String url = amazonS3.generatePresignedUrl(bucketName, filePath, calendar.getTime(), httpMethod).toString();
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, filePath)
+			.withMethod(httpMethod)
+			.withExpiration(calendar.getTime())
+			.withContentType("image/webp");
+
+		String url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
 
 		return S3UrlResponseDTO.builder()
 			.preSignedUrl(url)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#150 

## S3 버킷 관리
- 기존에 이미지 파일명으로 바로 저장 -> 임시 저장 경로 `/temp`와 실제 저장 경로 `/final `로 분리 
- 각 경로 안에 {userId}를 경로에 포함시켜 유저 별 파일 관리

## 🐞 수정사항
- `FileUploadController` -> `S3UploadController`, `FileUploadService` -> `S3UploadService` 로 클래스명 수정
- Presigned URL 발급 시 이미지 저장 경로 변경 `/temp/{userId}` 

[이벤트]
- 이벤트 생성 시 DB에 저장 후` /temp`에 저장된 이미지 파일을 `/final`로 이동 후 **bannerImageUrl** 경로 업데이트
- 이벤트 수정은 기존 **bannerImageUrl** 경로를 가져와 S3에서 제거 후 새로 저장된 이미지 파일을 /final 에 저장 후 업데이트

[호스트 채널]
- 호스트 채널 생성 시 DB에 저장 후` /temp`에 저장된 이미지 파일을 `/final`로 이동 후 **profileImageUrl** 경로 업데이트
- 호스트 채널 수정은 기존 **profileImageUrl** 경로를 가져와 S3에서 제거 후 새로 저장된 이미지 파일을 /final 에 저장 후 업데이트

<br>

`/temp` 에 저장된 이미지들은 S3 수명관리를 통해 주기적으로 삭제 스케줄링

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [x] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.