### PR TITLE
[fix] oauth 인증 실패 리다이렉트 경로 설정

### DIFF
--- a/src/main/java/com/gotogether/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gotogether/global/apipayload/code/status/ErrorStatus.java
@@ -48,10 +48,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	_ORDER_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "ORDER4003", "이미 취소된 주문입니다."),
 	_ORDER_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "ORDER4004", "이미 승인된 주문입니다."),
 
-	_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN4001", "토큰이 만료되었습니다."),
+	_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN4001", "로그인이 만료되었습니다."),
 	_TOKEN_TYPE_ERROR(HttpStatus.BAD_REQUEST, "TOKEN4002", "토큰 타입이 잘못되었습니다."),
-	_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "TOKEN4003", "로그아웃된 토큰입니다. 다시 로그인해주세요."),
-	_TOKEN_NOT_EXISTS(HttpStatus.UNAUTHORIZED, "TOKEN4004", "토큰이 존재하지 않습니다. 로그인이 필요합니다."),
+	_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "TOKEN4003", "로그아웃되었습니다. 다시 로그인해주세요."),
+	_TOKEN_NOT_EXISTS(HttpStatus.UNAUTHORIZED, "TOKEN4004", "로그인이 필요합니다."),
 
 	_BOOKMARK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "BOOKMARK4001", "이미 북마크된 이벤트입니다."),
 	_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4002", "북마크를 찾을 수 없습니다."),

--- a/src/main/java/com/gotogether/global/oauth/handler/CustomFailureHandler.java
+++ b/src/main/java/com/gotogether/global/oauth/handler/CustomFailureHandler.java
@@ -2,13 +2,12 @@ package com.gotogether.global.oauth.handler;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
-import com.gotogether.global.apipayload.code.status.ErrorStatus;
 import com.gotogether.global.oauth.exception.DuplicatedEmailException;
-import com.gotogether.global.oauth.util.ErrorResponseUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -16,14 +15,23 @@ import jakarta.servlet.http.HttpServletResponse;
 @Component
 public class CustomFailureHandler implements AuthenticationFailureHandler {
 
+	@Value("${app.redirect-url}")
+	String redirectUrl;
+
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException {
 
+		String status;
+
 		if (exception instanceof DuplicatedEmailException) {
-			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._USER_EMAIL_ALREADY_EXISTS);
+			status = "duplicatedEmail";
 		} else {
-			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._INTERNAL_SERVER_ERROR);
+			status = "serverError";
 		}
+
+		String targetUrl = redirectUrl + status;
+
+		response.sendRedirect(targetUrl);
 	}
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🐞수정사항
- oauth 인증 실패 핸들러에 에러 핸들링 -> 리다이렉트로 설정
- 중복 이메일 가입 시 status 파라미터 `duplicatedEmail` 로 전달
- 서버 인증 에러 시 status 파라미터 `serverError`로 전달
- Token ErroStatus 메세지 수정

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.