### PR TITLE
[fix] 티켓 동시 구매 시 DeadLock 발생하는 문제 해결

### DIFF
--- a/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
@@ -25,6 +25,7 @@ import com.gotogether.domain.order.util.OrderCodeGenerator;
 import com.gotogether.domain.ticket.entity.Ticket;
 import com.gotogether.domain.ticket.entity.TicketStatus;
 import com.gotogether.domain.ticket.entity.TicketType;
+import com.gotogether.domain.ticket.repository.TicketRepository;
 import com.gotogether.domain.ticketoptionanswer.dto.request.TicketOptionAnswerRequestDTO;
 import com.gotogether.domain.ticketoptionanswer.service.TicketOptionAnswerService;
 import com.gotogether.domain.ticketqrcode.entity.TicketQrCode;
@@ -40,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 public class OrderServiceImpl implements OrderService {
 
 	private final OrderRepository orderRepository;
+	private final TicketRepository ticketRepository;
 	private final EventFacade eventFacade;
 	private final TicketQrCodeService ticketQrCodeService;
 	private final OrderCustomRepository orderCustomRepository;
@@ -49,7 +51,8 @@ public class OrderServiceImpl implements OrderService {
 	@Transactional
 	public List<Order> createOrder(OrderRequestDTO request, Long userId) {
 		User user = eventFacade.getUserById(userId);
-		Ticket ticket = eventFacade.getTicketById(request.getTicketId());
+		Ticket ticket = ticketRepository.findByIdWithPessimisticLock(request.getTicketId())
+			.orElseThrow(() -> new GeneralException(ErrorStatus._TICKET_NOT_FOUND));
 
 		int ticketCnt = request.getTicketCnt();
 		checkTicketAvailableQuantity(ticket, ticketCnt);

--- a/src/main/java/com/gotogether/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/gotogether/domain/ticket/repository/TicketRepository.java
@@ -1,13 +1,23 @@
 package com.gotogether.domain.ticket.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.gotogether.domain.ticket.entity.Ticket;
 
+import jakarta.persistence.LockModeType;
+
 @Repository
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
 	List<Ticket> findByEventId(Long eventId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT t FROM Ticket t WHERE t.id = :id")
+	Optional<Ticket> findByIdWithPessimisticLock(Long id);
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## ❗️ 문제 상황
한 티켓 데이터에 여러 사용자가 동시에 구매(접근)을 하여 티켓의 남은 수량과 주문 데이터가 일치하지 않는 문제 발생


<img width="1250" alt="image" src="https://github.com/user-attachments/assets/353ae743-d11f-4d80-bc3b-314590b1efe8" />

### 원인
트랜잭션1, 트랜잭션2가  동일한 레코드에 서로 가진 S Lock을 해제하지 못한 채 X Lock을 기다리면서 데드락이 발생

### 해결 방법
비관적 락을 적용해 티켓 수량 조회 시점에 즉시 락 획득하여 다른 트랜잭션이 접근하지 못하도록 구현, 동일한 티켓을 안정적으로 처리되도록 구성

## 🐞수정사항
- 티켓 조회 쿼리에 `@Lock(LockModeType.PESSIMISTIC_WRITE)` 을 적용해 티켓을 조회 시점에 비관적 락 적용

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.