### PR TITLE
[fix] TicketOption 미사용 메서드 제거 및 티켓별 응답 조회 메서드명 수정

### DIFF
--- a/src/main/java/com/gotogether/domain/ticketoption/converter/TicketOptionConverter.java
+++ b/src/main/java/com/gotogether/domain/ticketoption/converter/TicketOptionConverter.java
@@ -3,10 +3,8 @@ package com.gotogether.domain.ticketoption.converter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.gotogether.domain.ticket.entity.Ticket;
 import com.gotogether.domain.ticketoption.dto.request.TicketOptionRequestDTO;
 import com.gotogether.domain.ticketoption.dto.response.TicketOptionChoiceResponseDTO;
-import com.gotogether.domain.ticketoption.dto.response.TicketOptionPerTicketResponseDTO;
 import com.gotogether.domain.ticketoption.dto.response.TicketOptionDetailResponseDTO;
 import com.gotogether.domain.ticketoption.entity.TicketOption;
 import com.gotogether.domain.ticketoption.entity.TicketOptionChoice;
@@ -31,16 +29,6 @@ public class TicketOptionConverter {
 				.name(name)
 				.build())
 			.collect(Collectors.toList());
-	}
-
-	public static TicketOptionPerTicketResponseDTO toTicketOptionPerTicketResponseDTO(Ticket ticket, List<TicketOption> ticketOptions) {
-		return TicketOptionPerTicketResponseDTO.builder()
-			.ticketId(ticket.getId())
-			.ticketName(ticket.getName())
-			.options(ticketOptions.stream()
-				.map(TicketOptionConverter::toTicketOptionDetailResponseDTO)
-				.collect(Collectors.toList()))
-			.build();
 	}
 
 	public static TicketOptionDetailResponseDTO toTicketOptionDetailResponseDTO(TicketOption ticketOption) {

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/controller/TicketOptionAnswerApi.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/controller/TicketOptionAnswerApi.java
@@ -60,7 +60,7 @@ public interface TicketOptionAnswerApi {
 		)
 	})
 	@GetMapping
-	ApiResponse<List<PurchaserAnswerDetailResponseDTO>> getAnswersByUserAndTicket(
+	ApiResponse<List<PurchaserAnswerDetailResponseDTO>> getAnswersByTicket(
 		@Parameter(description = "티켓 ID", required = true) @RequestParam Long ticketId
 	);
 

--- a/src/main/java/com/gotogether/domain/ticketoptionanswer/controller/TicketOptionAnswerController.java
+++ b/src/main/java/com/gotogether/domain/ticketoptionanswer/controller/TicketOptionAnswerController.java
@@ -34,7 +34,7 @@ public class TicketOptionAnswerController implements TicketOptionAnswerApi {
 	}
 
 	@GetMapping
-	public ApiResponse<List<PurchaserAnswerDetailResponseDTO>> getAnswersByUserAndTicket(
+	public ApiResponse<List<PurchaserAnswerDetailResponseDTO>> getAnswersByTicket(
 		@RequestParam Long ticketId) {
 		List<PurchaserAnswerDetailResponseDTO> answers = ticketOptionAnswerService.getAnswersByTicket(ticketId);
 		return ApiResponse.onSuccess(answers);


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🐞수정사항
- TicketOptionConverter의 `toTicketOptionPerTicketResponseDTO` 미사용 메서드 제거
- TicketOptionAnswerController 메서드명 수정 `getAnswersByUserAndTicket` -> `getAnswersByTicket`

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 문서 수정
- [x] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.