### PR TITLE
[feature] 요청 바디 로깅 기능 구현

### DIFF
--- a/src/main/java/com/gotogether/global/filter/CachingRequestResponseFilter.java
+++ b/src/main/java/com/gotogether/global/filter/CachingRequestResponseFilter.java
@@ -8,11 +8,11 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 
-// TODO: 요청 바디 로깅 필터 추가
 @Component
 public class CachingRequestResponseFilter implements Filter {
     @Override
@@ -20,9 +20,11 @@ public class CachingRequestResponseFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         
+        ContentCachingRequestWrapper cachingRequest = new ContentCachingRequestWrapper(httpRequest); 
         ContentCachingResponseWrapper cachingResponse = new ContentCachingResponseWrapper(httpResponse);
         
-        chain.doFilter(httpRequest, cachingResponse);
+        chain.doFilter(cachingRequest, cachingResponse);
+        
         cachingResponse.copyBodyToResponse();
     }
 }

--- a/src/main/java/com/gotogether/global/interceptor/LoggingInterceptor.java
+++ b/src/main/java/com/gotogether/global/interceptor/LoggingInterceptor.java
@@ -3,6 +3,7 @@ package com.gotogether.global.interceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,8 +30,11 @@ public class LoggingInterceptor implements HandlerInterceptor {
         Long startTime = (Long) request.getAttribute(START_TIME);
         long duration = (startTime != null) ? (System.currentTimeMillis() - startTime) : -1;
 
+        logRequestBody(request);
+        
         logger.info("[응답] {} {} (상태: {}, 시간: {}ms)", 
             request.getMethod(), request.getRequestURI(), response.getStatus(), duration);
+
         logResponseHeaders(response);
         logResponseBody(response);
     }
@@ -42,6 +46,15 @@ public class LoggingInterceptor implements HandlerInterceptor {
         );
         if (sb.length() > 0) {
             logger.info("요청 헤더: {}", sb.toString());
+        }
+    }
+
+    private void logRequestBody(HttpServletRequest request) {
+        if (request instanceof ContentCachingRequestWrapper wrapper) {
+            String body = new String(wrapper.getContentAsByteArray());
+            if (!body.isEmpty()) {
+                logger.info("요청 바디: {}", body);
+            }
         }
     }
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
요청 바디 로깅 기능 구현

## PR
어떤 변경 사항이 있나요?
### ⭐️ 요청 바디 로깅 기능 구현
- 기존에 preHandle에서 요청 바디를 로깅하면 정상적으로 출력되지 않는 문제가 있었는데, 이는 컨트롤러 실행 전에 요청 바디가 아직 읽히지 않는 시점이기 때문입니다.
- `ContentCachingRequestWrapper`는 요청 바디가 실제로 읽힐 때(`@RequestBody` 바인딩 시점) 캐싱되므로, 컨트롤러 실행 후인 `afterCompletion`에서 로깅하도록 구현했습니다.
  - **Filter → preHandle → Controller (`@RequestBody` 읽음) → afterCompletion**

---
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.