### PR TITLE
[refactor] Order, Ticket 비즈니스 로직을 Entity로 이동시켜 Service 간소화

### DIFF
--- a/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
@@ -231,11 +231,12 @@ public class HostChannelServiceImpl implements HostChannelService {
 
 		if (order.getTicket().getEvent().getOnlineType() == OnlineType.OFFLINE) {
 			TicketQrCode ticketQrCode = ticketQrCodeService.createQrCode(order);
-			order.updateTicketQrCode(ticketQrCode);
+			order.assignQrCode(ticketQrCode);
 
 			orderRepository.save(order);
 		}
-		order.approveOrder();
+
+		order.approve();
 	}
 
 	@Override

--- a/src/main/java/com/gotogether/domain/order/converter/OrderConverter.java
+++ b/src/main/java/com/gotogether/domain/order/converter/OrderConverter.java
@@ -11,22 +11,11 @@ import com.gotogether.domain.order.dto.response.OrderInfoResponseDTO;
 import com.gotogether.domain.order.dto.response.OrderedTicketResponseDTO;
 import com.gotogether.domain.order.dto.response.TicketPurchaserEmailResponseDTO;
 import com.gotogether.domain.order.entity.Order;
-import com.gotogether.domain.order.entity.OrderStatus;
 import com.gotogether.domain.ticket.entity.Ticket;
 import com.gotogether.domain.ticketqrcode.entity.TicketQrCode;
-import com.gotogether.domain.user.entity.User;
 
 @Component
 public class OrderConverter {
-
-	public static Order of(User user, Ticket ticket, String orderCode, OrderStatus status) {
-		return Order.builder()
-			.user(user)
-			.ticket(ticket)
-			.orderCode(orderCode)
-			.status(status)
-			.build();
-	}
 
 	public static OrderedTicketResponseDTO toOrderedTicketResponseDTO(Order order) {
 		Ticket ticket = order.getTicket();

--- a/src/main/java/com/gotogether/domain/order/entity/Order.java
+++ b/src/main/java/com/gotogether/domain/order/entity/Order.java
@@ -1,6 +1,7 @@
 package com.gotogether.domain.order.entity;
 
 import com.gotogether.domain.ticket.entity.Ticket;
+import com.gotogether.domain.ticket.entity.TicketType;
 import com.gotogether.domain.ticketqrcode.entity.TicketQrCode;
 import com.gotogether.domain.user.entity.User;
 import com.gotogether.global.common.entity.BaseEntity;
@@ -57,6 +58,19 @@ public class Order extends BaseEntity {
 		this.user = user;
 		this.ticket = ticket;
 	}
+
+    public static Order create(User user, Ticket ticket, String orderCode, TicketType ticketType) {
+        OrderStatus initialStatus = (ticketType == TicketType.FIRST_COME)
+            ? OrderStatus.COMPLETED
+            : OrderStatus.PENDING;
+
+        return Order.builder()
+            .user(user)
+            .ticket(ticket)
+            .orderCode(orderCode)
+            .status(initialStatus)
+            .build();
+    }
 
 	public void updateTicketQrCode(TicketQrCode ticketQrCode) {
 		this.ticketQrCode = ticketQrCode;

--- a/src/main/java/com/gotogether/domain/order/entity/Order.java
+++ b/src/main/java/com/gotogether/domain/order/entity/Order.java
@@ -4,6 +4,8 @@ import com.gotogether.domain.ticket.entity.Ticket;
 import com.gotogether.domain.ticket.entity.TicketType;
 import com.gotogether.domain.ticketqrcode.entity.TicketQrCode;
 import com.gotogether.domain.user.entity.User;
+import com.gotogether.global.apipayload.code.status.ErrorStatus;
+import com.gotogether.global.apipayload.exception.GeneralException;
 import com.gotogether.global.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -72,16 +74,45 @@ public class Order extends BaseEntity {
             .build();
     }
 
+    /**
+     * @deprecated Use {@link #assignQrCode(TicketQrCode)} instead
+     */
+    @Deprecated
 	public void updateTicketQrCode(TicketQrCode ticketQrCode) {
-		this.ticketQrCode = ticketQrCode;
-		ticketQrCode.updateOrder(this);
+		assignQrCode(ticketQrCode);
 	}
 
+    /**
+     * @deprecated Use {@link #cancel()} instead
+     */
+    @Deprecated
 	public void cancelOrder() {
-		this.status = OrderStatus.CANCELED;
+		cancel();
 	}
 
-	public void approveOrder() {
-		this.status = OrderStatus.COMPLETED;
-	}
+    /**
+     * @deprecated Use {@link #approve()} instead
+     */
+    public void approveOrder() {
+        approve();
+    }
+
+    public void validateOwner(User user) {
+        if(!this.user.equals(user)) {
+            throw new GeneralException(ErrorStatus._ORDER_NOT_MATCH_USER);
+        }
+    }
+
+    public void assignQrCode(TicketQrCode ticketQrCode) {
+        this.ticketQrCode = ticketQrCode;
+        ticketQrCode.updateOrder(this);
+    }
+
+    public void approve(){
+        this.status = OrderStatus.COMPLETED;
+    }
+
+    public void cancel(){
+        this.status = OrderStatus.CANCELED;
+    }
 }

--- a/src/main/java/com/gotogether/domain/order/entity/Order.java
+++ b/src/main/java/com/gotogether/domain/order/entity/Order.java
@@ -74,29 +74,6 @@ public class Order extends BaseEntity {
             .build();
     }
 
-    /**
-     * @deprecated Use {@link #assignQrCode(TicketQrCode)} instead
-     */
-    @Deprecated
-	public void updateTicketQrCode(TicketQrCode ticketQrCode) {
-		assignQrCode(ticketQrCode);
-	}
-
-    /**
-     * @deprecated Use {@link #cancel()} instead
-     */
-    @Deprecated
-	public void cancelOrder() {
-		cancel();
-	}
-
-    /**
-     * @deprecated Use {@link #approve()} instead
-     */
-    public void approveOrder() {
-        approve();
-    }
-
     public void validateOwner(User user) {
         if(!this.user.equals(user)) {
             throw new GeneralException(ErrorStatus._ORDER_NOT_MATCH_USER);

--- a/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
@@ -107,15 +107,13 @@ public class OrderServiceImpl implements OrderService {
 			Order order = orderRepository.findById(orderId)
 				.orElseThrow(() -> new GeneralException(ErrorStatus._ORDER_NOT_FOUND));
 
-			if (!order.getUser().equals(user)) {
-				throw new GeneralException(ErrorStatus._ORDER_NOT_MATCH_USER);
-			}
+			order.validateOwner(user);
 
 			Ticket ticket = eventFacade.getTicketById(order.getTicket().getId());
 
 			metricService.recordOrderCancellation(ticket.getEvent().getId(), ticket.getPrice());
 
-			order.cancelOrder();
+			order.cancel();
 			ticket.restoreStock();
 			ticketQrCodeService.deleteQrCode(orderId);
 			orderRepository.save(order);
@@ -139,7 +137,8 @@ public class OrderServiceImpl implements OrderService {
 
 		if (ticket.getType() == TicketType.FIRST_COME && event.getOnlineType() == OnlineType.OFFLINE) {
 			TicketQrCode ticketQrCode = ticketQrCodeService.createQrCode(order);
-			order.updateTicketQrCode(ticketQrCode);
+
+            order.assignQrCode(ticketQrCode);
 
 			orderRepository.save(order);
 		}

--- a/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
@@ -1,6 +1,5 @@
 package com.gotogether.domain.order.service;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +22,6 @@ import com.gotogether.domain.order.repository.OrderCustomRepository;
 import com.gotogether.domain.order.repository.OrderRepository;
 import com.gotogether.domain.order.util.OrderCodeGenerator;
 import com.gotogether.domain.ticket.entity.Ticket;
-import com.gotogether.domain.ticket.entity.TicketStatus;
 import com.gotogether.domain.ticket.entity.TicketType;
 import com.gotogether.domain.ticket.repository.TicketRepository;
 import com.gotogether.domain.ticketoptionanswer.dto.request.TicketOptionAnswerRequestDTO;
@@ -57,11 +55,8 @@ public class OrderServiceImpl implements OrderService {
 			.orElseThrow(() -> new GeneralException(ErrorStatus._TICKET_NOT_FOUND));
 
 		int ticketCnt = request.getTicketCnt();
-		checkTicketAvailableQuantity(ticket, ticketCnt);
 
-		checkTicketStatus(ticket);
-
-		checkTicketStartDateOrEndDate(ticket);
+        ticket.validatePurchasable(ticketCnt);
 
 		List<Order> orders = new ArrayList<>();
 
@@ -122,7 +117,7 @@ public class OrderServiceImpl implements OrderService {
 			metricService.recordOrderCancellation(ticket.getEvent().getId(), ticket.getPrice());
 
 			order.cancelOrder();
-			ticket.increaseAvailableQuantity();
+			ticket.restoreStock();
 			ticketQrCodeService.deleteQrCode(orderId);
 			orderRepository.save(order);
 		}
@@ -133,24 +128,6 @@ public class OrderServiceImpl implements OrderService {
 	public TicketPurchaserEmailResponseDTO getPurchaserEmails(Long ticketId) {
 		List<String> purchaserEmails = orderRepository.findPurchaserEmailsByTicketId(ticketId);
 		return OrderConverter.toPurchaserEmailResponseDTO(purchaserEmails);
-	}
-
-	private void checkTicketAvailableQuantity(Ticket ticket, int ticketCnt) {
-		if (ticket.getAvailableQuantity() < ticketCnt) {
-			throw new GeneralException(ErrorStatus._TICKET_NOT_ENOUGH);
-		}
-	}
-
-	private void checkTicketStatus(Ticket ticket) {
-		if (ticket.getStatus() == TicketStatus.CLOSE) {
-			throw new GeneralException(ErrorStatus._TICKET_ALREADY_CLOSED);
-		}
-	}
-
-	private void checkTicketStartDateOrEndDate(Ticket ticket) {
-		if (ticket.getStartDate().isAfter(LocalDateTime.now()) || ticket.getEndDate().isBefore(LocalDateTime.now())) {
-			throw new GeneralException(ErrorStatus._TICKET_SALE_UNAVAILABLE);
-		}
 	}
 
 	private Order createTicketOrder(User user, Ticket ticket) {
@@ -172,7 +149,7 @@ public class OrderServiceImpl implements OrderService {
 			orderRepository.save(order);
 		}
 
-		ticket.decreaseAvailableQuantity();
+		ticket.decreaseStock();
 		return order;
 	}
 

--- a/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
@@ -17,7 +17,6 @@ import com.gotogether.domain.order.dto.response.OrderInfoResponseDTO;
 import com.gotogether.domain.order.dto.response.OrderedTicketResponseDTO;
 import com.gotogether.domain.order.dto.response.TicketPurchaserEmailResponseDTO;
 import com.gotogether.domain.order.entity.Order;
-import com.gotogether.domain.order.entity.OrderStatus;
 import com.gotogether.domain.order.repository.OrderCustomRepository;
 import com.gotogether.domain.order.repository.OrderRepository;
 import com.gotogether.domain.order.util.OrderCodeGenerator;
@@ -135,11 +134,7 @@ public class OrderServiceImpl implements OrderService {
 
 		String orderCode = generateOrderCode();
 
-		OrderStatus status = (ticket.getType() == TicketType.FIRST_COME)
-			? OrderStatus.COMPLETED
-			: OrderStatus.PENDING;
-
-		Order order = OrderConverter.of(user, ticket, orderCode, status);
+		Order order = Order.create(user, ticket, orderCode, ticket.getType());
 		orderRepository.save(order);
 
 		if (ticket.getType() == TicketType.FIRST_COME && event.getOnlineType() == OnlineType.OFFLINE) {

--- a/src/main/java/com/gotogether/domain/ticket/converter/TicketConverter.java
+++ b/src/main/java/com/gotogether/domain/ticket/converter/TicketConverter.java
@@ -1,26 +1,9 @@
 package com.gotogether.domain.ticket.converter;
 
-import com.gotogether.domain.event.entity.Event;
-import com.gotogether.domain.ticket.dto.request.TicketRequestDTO;
 import com.gotogether.domain.ticket.dto.response.TicketListResponseDTO;
 import com.gotogether.domain.ticket.entity.Ticket;
-import com.gotogether.domain.ticket.entity.TicketStatus;
 
 public class TicketConverter {
-
-	public static Ticket of(TicketRequestDTO request, Event event) {
-		return Ticket.builder()
-			.type(request.getTicketType())
-			.event(event)
-			.name(request.getTicketName())
-			.description(request.getTicketDescription())
-			.price(request.getTicketPrice())
-			.availableQuantity(request.getAvailableQuantity())
-			.startDate(request.getStartDate())
-			.endDate(request.getEndDate())
-			.status(TicketStatus.OPEN)
-			.build();
-	}
 
 	public static TicketListResponseDTO toTicketListResponseDTO(Ticket ticket) {
 		return TicketListResponseDTO.builder()

--- a/src/main/java/com/gotogether/domain/ticket/entity/Ticket.java
+++ b/src/main/java/com/gotogether/domain/ticket/entity/Ticket.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import com.gotogether.domain.event.entity.Event;
 import com.gotogether.domain.ticketoptionassignment.entity.TicketOptionAssignment;
+import com.gotogether.global.apipayload.code.status.ErrorStatus;
+import com.gotogether.global.apipayload.exception.GeneralException;
 import com.gotogether.global.common.entity.BaseEntity;
 
 import jakarta.persistence.CascadeType;
@@ -83,15 +85,40 @@ public class Ticket extends BaseEntity {
 		this.status = status;
 	}
 
-	public void decreaseAvailableQuantity() {
-		this.availableQuantity--;
-	}
+    public void decreaseStock() {
+        this.availableQuantity--;
+    }
 
-	public void increaseAvailableQuantity() {
-		this.availableQuantity++;
-	}
+    public void restoreStock() {
+        this.availableQuantity++;
+    }
 
-	public void updateStatus(TicketStatus status) {
-		this.status = status;
-	}
+    public void close(){
+        this.status = TicketStatus.CLOSE;
+    }
+
+    public void validatePurchasable(int requestQuantity) {
+        validateQuantity(requestQuantity);
+        validateStatus();
+        validateSalePeriod();
+    }
+
+    private void validateQuantity(int requestQuantity) {
+        if(this.availableQuantity < requestQuantity) {
+            throw new GeneralException(ErrorStatus._TICKET_NOT_ENOUGH);
+        }
+    }
+
+    private void validateStatus() {
+        if(this.status == TicketStatus.CLOSE){
+            throw new GeneralException(ErrorStatus._TICKET_ALREADY_CLOSED);
+        }
+    }
+
+    private void validateSalePeriod() {
+        LocalDateTime now = LocalDateTime.now();
+        if(this.startDate.isAfter(now) || this.endDate.isBefore(now)){
+            throw new GeneralException(ErrorStatus._TICKET_SALE_UNAVAILABLE);
+        }
+    }
 }

--- a/src/main/java/com/gotogether/domain/ticket/entity/Ticket.java
+++ b/src/main/java/com/gotogether/domain/ticket/entity/Ticket.java
@@ -85,6 +85,29 @@ public class Ticket extends BaseEntity {
 		this.status = status;
 	}
 
+    public static Ticket create(
+            Event event,
+            String name,
+            int price,
+            String description,
+            int availableQuantity,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            TicketType type
+    ) {
+        return Ticket.builder()
+                .event(event)
+                .name(name)
+                .price(price)
+                .description(description)
+                .availableQuantity(availableQuantity)
+                .startDate(startDate)
+                .endDate(endDate)
+                .type(type)
+                .status(TicketStatus.OPEN)
+                .build();
+    }
+
     public void decreaseStock() {
         this.availableQuantity--;
     }

--- a/src/main/java/com/gotogether/domain/ticket/service/TicketServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/ticket/service/TicketServiceImpl.java
@@ -30,7 +30,16 @@ public class TicketServiceImpl implements TicketService {
 	@Transactional
 	public Ticket createTicket(TicketRequestDTO request) {
 		Event event = eventFacade.getEventById(request.getEventId());
-		Ticket ticket = TicketConverter.of(request, event);
+		Ticket ticket = Ticket.create(
+                event,
+                request.getTicketName(),
+                request.getTicketPrice(),
+                request.getTicketDescription(),
+                request.getAvailableQuantity(),
+                request.getStartDate(),
+                request.getEndDate(),
+                request.getTicketType()
+        );
 
 		ticketRepository.save(ticket);
 

--- a/src/main/java/com/gotogether/domain/ticket/service/TicketServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/ticket/service/TicketServiceImpl.java
@@ -11,7 +11,6 @@ import com.gotogether.domain.ticket.converter.TicketConverter;
 import com.gotogether.domain.ticket.dto.request.TicketRequestDTO;
 import com.gotogether.domain.ticket.dto.response.TicketListResponseDTO;
 import com.gotogether.domain.ticket.entity.Ticket;
-import com.gotogether.domain.ticket.entity.TicketStatus;
 import com.gotogether.domain.ticket.repository.TicketRepository;
 import com.gotogether.global.apipayload.code.status.ErrorStatus;
 import com.gotogether.global.apipayload.exception.GeneralException;
@@ -62,7 +61,7 @@ public class TicketServiceImpl implements TicketService {
 	@Transactional
 	public void updateTicketStatusToCompleted(Long ticketId) {
 		Ticket ticket = getTicketById(ticketId);
-		ticket.updateStatus(TicketStatus.CLOSE);
+		ticket.close();
 	}
 
 	private Ticket getTicketById(Long ticketId) {

--- a/src/test/java/com/gotogether/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/gotogether/domain/order/OrderServiceTest.java
@@ -215,7 +215,7 @@ class OrderServiceTest {
     @DisplayName("[예외] 이미 종료된 티켓일 때 주문 생성 실패")
     void createOrder_Fail_AlreadyClosed() {
         // GIVEN
-        ticket.updateStatus(TicketStatus.CLOSE); // 상태를 CLOSE로 변경
+        ticket.close(); // 상태를 CLOSE로 변경
         OrderRequestDTO request = OrderRequestDTO.builder().ticketId(1L).ticketCnt(1).build();
 
         when(eventFacade.getUserById(any())).thenReturn(user);

--- a/src/test/java/com/gotogether/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/gotogether/domain/order/OrderServiceTest.java
@@ -92,7 +92,7 @@ class OrderServiceTest {
 
         ticketQrCode = TicketQrCode.builder().order(order).qrCodeImageUrl("https://example.com/qr-code.png").status(TicketQrCodeStatus.AVAILABLE).build();
 
-        order.updateTicketQrCode(ticketQrCode);
+        order.assignQrCode(ticketQrCode);
     }
 
     @Test

--- a/src/test/java/com/gotogether/domain/ticketqrcode/TicketQrCodeServiceTest.java
+++ b/src/test/java/com/gotogether/domain/ticketqrcode/TicketQrCodeServiceTest.java
@@ -116,7 +116,7 @@ class TicketQrCodeServiceTest {
 			.build();
 		ReflectionTestUtils.setField(ticketQrCode, "id", 1L);
 
-		order.updateTicketQrCode(ticketQrCode);
+		order.assignQrCode(ticketQrCode);
 	}
 
 	@Test


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
Order와 Ticket 도메인에서 Service Layer에 집중되어 있던 비즈니스 로직을 Entity로 이동했다.
이를 통해 Entity가 스스로 상태와 규칙을 관리하도록 하고, Service는 흐름 제어에 집중할 수 있도록 구조를 개선했다.

## PR
어떤 변경 사항이 있나요?

### 1. Entity 비즈니스 로직 추가 및 Service 간소화
**Order**
- 주문 생성 시, Converter 대신 정적 팩토리 메서드 `Order.create()`를 사용하도록 변경했다.
- 주문 생성 시, 수행되는 구매 가능 여부 검증 로직을 Service에서 제거하고 Entity 메서드 `Ticket.validatePurchasable()`를 사용하도록 변경했다.
- 주문 취소 시, 수행되는 소유자 검증 로직을 Entity 메서드 `validateOwner(user)`를 사용하도록 변경했다.

**Ticket**
- 티켓 생성 시, Converter 대신 정적 팩토리 메서드 `Ticket.create()`를 사용하도록 변경했다.
- 기존에 `OrderServiceImpl`에 있던 구매 가능 여부 검증 로직을 Entity 메서드 `validatePurchasable()`로 통합했다.

### 2. EventConverter 로직 유지
`OrderConverter`에서 `EventConverter` 호출을 제거해 순환 참조를 방지하려 했으나, 이로 인해 중복 코드가 다수 발생할 수 있다고 판단했다.
`EventConverter`가 `OrderConverter`를 참조할 가능성이 낮다고 판단해, 중복을 줄이기 위해 기존 `EventConverter` 로직을 유지하기로 결정했다.

### 3. 이슈 외의 작업 내용
- Order Entity의 주문 승인, 주문 취소, QR 코드 할당 메서드명을 변경했다.
- Ticket Entity의 티켓 재고 관리, 티켓 종료 메서드명을 변경하고, 티켓 종료 메서드가 `TicketServiceImpl`에서 티켓의 상태를 변경하지 않고 Entity에서 변경하도록 코드를 수정해 캡슐화했다.

---
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.